### PR TITLE
$show variable fails when no results in wp_query

### DIFF
--- a/display-widgets.php
+++ b/display-widgets.php
@@ -113,7 +113,8 @@ class DWPlugin{
 			$show = isset( $instance[ 'tax-' . $term->taxonomy ] ) ? $instance[ 'tax-'. $term->taxonomy] : false;
 			unset( $term );
 		} else if ( is_post_type_archive() ) {
-			$type = get_post_type();
+			global $wp_query;
+			$type = (get_post_type() === false) ? $wp_query->query["post_type"] : get_post_type();
 			$show = isset( $instance[ 'type-' . $type . '-archive' ] ) ? $instance[ 'type-' . $type . '-archive' ] : false;
 		} else if ( is_archive() ) {
 			$show = isset( $instance['page-archive'] ) ? $instance['page-archive'] : false;


### PR DESCRIPTION
The $type variable is set to false when there are no results for a wp_query on the archive page. This way we have a fallback to get the correct post_type even when no results are present.