### PR TITLE
Add priority to the 'widget_display_callback' filter

### DIFF
--- a/display-widgets.php
+++ b/display-widgets.php
@@ -40,7 +40,7 @@ class DWPlugin{
 	var $langs = array();
     
 	function __construct(){
-		add_filter( 'widget_display_callback', array( &$this, 'show_widget' ) );
+		add_filter( 'widget_display_callback', array( &$this, 'show_widget' ), 10 );
         
 		// change the hook that triggers widget check
 		$hook = apply_filters( 'dw_callback_trigger', 'wp_loaded' );


### PR DESCRIPTION
Set a priority for the widget_display_callback filter so that other plugins can also short circuit widgets by coming afterwards.  Because show_widget returns an $instance that is not null if it does not match, if it comes after the other plugin's filter, the widget will still display, even if the first filter returns false.